### PR TITLE
Add set version support

### DIFF
--- a/pygore/internal.py
+++ b/pygore/internal.py
@@ -106,6 +106,11 @@ _c_open.argtypes = [c_char_p]
 _c_close = lib.close
 _c_close.argtypes = [c_char_p]
 
+# Call to set the compiler version
+_c_setCompilerVersion = lib.setGoVersion
+_c_setCompilerVersion.argtypes = [c_void_p, c_void_p]
+_c_setCompilerVersion.restype = c_int
+
 # Call to get compiler version.
 _c_getCompilerVersion = lib.getCompilerVersion
 _c_getCompilerVersion.argtypes = [c_void_p]

--- a/pygore/lib.py
+++ b/pygore/lib.py
@@ -3,6 +3,7 @@
 # can be found in the LICENSE file.
 
 import pygore.internal as internal
+from ctypes import c_char_p
 
 
 class CompilerVersion:
@@ -242,6 +243,17 @@ class GoFile:
         '''
         internal._c_close(self.path)
         self.path = None
+
+    def set_compiler_version(self, version):
+        '''
+        Set an assumed compiler version to be used when extracting information
+        from the binary.
+        '''
+        c_ver = c_char_p(version.encode('utf-8'))
+        v = internal._c_setCompilerVersion(self.path, c_ver)
+        if v != 0:
+            return True
+        return False
 
     def get_compiler_version(self):
         '''


### PR DESCRIPTION
This commit adds support for setting an assumed version.
This version has to be a valid Go version string.