### PR TITLE
Fix type being tuple

### DIFF
--- a/pygore/lib.py
+++ b/pygore/lib.py
@@ -366,7 +366,7 @@ def _convert_type(t, cache):
 
     typ = Type()
     typ.addr = int(t.addr)
-    typ.kind = int(t.kind),
+    typ.kind = int(t.kind)
     typ.name = str(t.name.decode('utf-8', 'replace'))
     typ.ptrResolved = int(t.ptrResolved)
     typ.packagePath = str(t.packagePath.decode('utf-8', 'replace'))


### PR DESCRIPTION
The type list values should also be included. It's an enum from reflect with the values starting at 0, i labeled struct explicitly for example

```
const (
	Invalid Kind = 0
	Bool
	Int
	Int8
	Int16
	Int32
	Int64
	Uint
	Uint8
	Uint16
	Uint32
	Uint64
	Uintptr
	Float32
	Float64
	Complex64
	Complex128
	Array
	Chan
	Func
	Interface
	Map
	Ptr
	Slice
	String
	Struct = 25
	UnsafePointer
)
```