### PR TITLE
Add fix for enum comparison

### DIFF
--- a/pygore/lib.py
+++ b/pygore/lib.py
@@ -385,7 +385,7 @@ def _convert_type(t, cache):
     typ.packagePath = str(t.packagePath.decode('utf-8', 'replace'))
 
     # If the type is a struct and has fields, extract field information.
-    if t.kind == Kind.Struct and t.fields:
+    if t.kind == Kind.Struct.value and t.fields:
         typ.fields = []
         for i in range(t.fields.contents.length):
             field = t.fields.contents.types[i].contents


### PR DESCRIPTION
Fixes #18 

Enum comparison has a small bug that causes the comparison to always return false, preventing typ.fields from being populated with the types.